### PR TITLE
fix compilation arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# cMake File 
+
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+.DS_Store
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required (VERSION 2.6)
 project (MeshFix)
 add_subdirectory(contrib/JMeshLib)
+link_directories(/usr/local/lib/)
 include_directories(
     include
     /usr/include/superlu
-    /usr/include/SuperLU
+    /usr/local/include/
     contrib/JMeshLib/include
     contrib/OpenNL3.2.1/src
     contrib/jrs_predicates

--- a/contrib/JMeshLib/include/clusterGraph.h
+++ b/contrib/JMeshLib/include/clusterGraph.h
@@ -54,8 +54,8 @@ class clusterHeap : abstractHeap
  ~clusterHeap() {delete(positions);}
 
  void push(clusterEdge *e) {insert((void *)(e->index));}
- clusterEdge *getFirst() {return (numels)?(edges[(j_voidint)getHead()]):(NULL);}
- clusterEdge *popHead() {return (numels)?(edges[(j_voidint)removeHead()]):(NULL);}
+ clusterEdge *getFirst() {return (numels)?(edges[(j_voidint)(size_t)getHead()]):(NULL);}
+ clusterEdge *popHead() {return (numels)?(edges[(j_voidint)(size_t)removeHead()]):(NULL);}
  int isEmpty() {return (numels==0);}
 
  void remove(clusterEdge *e)

--- a/contrib/JMeshLib/include/dijkstraGraph.h
+++ b/contrib/JMeshLib/include/dijkstraGraph.h
@@ -65,7 +65,7 @@ class dijkstraHeap : abstractHeap
 
  void push(dijkstraNode *n) {insert((void *)(n->index));}
  dijkstraNode *getHead() {return (dijkstraNode *)getHead();}
- dijkstraNode *popHead() {return (numels)?(nodes[(j_voidint)removeHead()]):(NULL);}
+ dijkstraNode *popHead() {return (numels)?(nodes[(j_voidint)(size_t)removeHead()]):(NULL);}
  int isEmpty() {return (numels==0);}
 
  void remove(dijkstraNode *n)

--- a/contrib/JMeshLib/src/MESH_STRUCTURE/io.cpp
+++ b/contrib/JMeshLib/src/MESH_STRUCTURE/io.cpp
@@ -682,7 +682,7 @@ int Triangulation::saveVRML1(const char *fname, const int mode)
    fprintf(fp,"Material {\n diffuseColor [\n");
    FOREACHTRIANGLE(t, n)
    {
-    pkc = (unsigned int)((j_voidint)t->info);
+    pkc = (unsigned int)((j_voidint)(size_t)t->info);
     fprintf(fp,"  %f %f %f,\n",((pkc>>24)&0x000000ff)/255.0,((pkc>>16)&0x000000ff)/255.0,((pkc>>8)&0x000000ff)/255.0);
    }
    fprintf(fp," ]\n}\nMaterialBinding {\n value PER_FACE_INDEXED\n}\n");
@@ -691,7 +691,7 @@ int Triangulation::saveVRML1(const char *fname, const int mode)
    fprintf(fp,"Material {\n diffuseColor [\n");
    FOREACHVERTEX(v, n)
    {
-    pkc = (unsigned int)((j_voidint)v->info);
+    pkc = (unsigned int)((j_voidint)(size_t)v->info);
     fprintf(fp,"  %f %f %f,\n",((pkc>>24)&0x000000ff)/255.0,((pkc>>16)&0x000000ff)/255.0,((pkc>>8)&0x000000ff)/255.0);
    }
    fprintf(fp," ]\n}\nMaterialBinding {\n value PER_VERTEX_INDEXED\n}\n");

--- a/contrib/JMeshLib/src/MESH_STRUCTURE/vertex.cpp
+++ b/contrib/JMeshLib/src/MESH_STRUCTURE/vertex.cpp
@@ -588,8 +588,8 @@ Edge *Vertex::inverseCollapse(Vertex *v2, Edge *e, Edge *e1, Edge *e2, Edge *e3,
 //// Returns the number of boundaries of the spherical neighborhood ////
 //// of radius 'r'.  						    ////
 
-#define INCREASE_INFO_FIELD(v) ((v)->info = (void *)(((j_voidint)(v)->info)+1))
-#define DECREASE_INFO_FIELD(v) ((v)->info = (void *)(((j_voidint)(v)->info)-2))
+#define INCREASE_INFO_FIELD(v) ((v)->info = (void *)(((j_voidint)(size_t)(v)->info)+1))
+#define DECREASE_INFO_FIELD(v) ((v)->info = (void *)(((j_voidint)(size_t)(v)->info)-2))
 
 int Vertex::getTopology(const double& r) const
 {

--- a/contrib/JMeshLib/src/PRIMITIVES/clusterGraph.cpp
+++ b/contrib/JMeshLib/src/PRIMITIVES/clusterGraph.cpp
@@ -30,8 +30,8 @@
 
 int clusterHeap::compare(const void *e1, const void *e2)
 {
- clusterEdge *a = edges[(j_voidint)e1];
- clusterEdge *b = edges[(j_voidint)e2];
+ clusterEdge *a = edges[(j_voidint)(size_t)e1];
+ clusterEdge *b = edges[(j_voidint)(size_t)e2];
  double l1 = a->cost;
  double l2 = b->cost;
 

--- a/contrib/JMeshLib/src/PRIMITIVES/dijkstraGraph.cpp
+++ b/contrib/JMeshLib/src/PRIMITIVES/dijkstraGraph.cpp
@@ -30,8 +30,8 @@
 
 int dijkstraHeap::compare(const void *n1, const void *n2)
 {
- dijkstraNode *a = nodes[(j_voidint)n1];
- dijkstraNode *b = nodes[(j_voidint)n2];
+ dijkstraNode *a = nodes[(j_voidint)(size_t)n1];
+ dijkstraNode *b = nodes[(j_voidint)(size_t)n2];
  double l1 = a->dist;
  double l2 = b->dist;
 

--- a/contrib/JMeshLib/src/PRIMITIVES/heap.cpp
+++ b/contrib/JMeshLib/src/PRIMITIVES/heap.cpp
@@ -56,8 +56,8 @@ int abstractHeap::upheap(int k)
   heap[fk] = t;
   if (positions != NULL)
   {
-   positions[(j_voidint)f] = k;
-   positions[(j_voidint)t] = fk;
+   positions[(j_voidint)(size_t)f] = k;
+   positions[(j_voidint)(size_t)t] = fk;
   }
   return upheap(fk);
  }
@@ -81,8 +81,8 @@ int abstractHeap::downheap(int k)
   heap[j] = t;
   if (positions != NULL)
   {
-   positions[(j_voidint)f] = k;
-   positions[(j_voidint)t] = j;
+   positions[(j_voidint)(size_t)f] = k;
+   positions[(j_voidint)(size_t)t] = j;
   }
   return downheap(j);
  }
@@ -95,18 +95,18 @@ int abstractHeap::insert(void *t)
  if (numels == maxels) return -1;
 
  heap[++numels] = t;
- if (positions != NULL) positions[(j_voidint)t] = numels;
+ if (positions != NULL) positions[(j_voidint)(size_t)t] = numels;
  return upheap(numels);
 }
 
 void *abstractHeap::removeHead()
 {
  void *t = heap[1];
- if (positions != NULL) positions[(j_voidint)t] = 0;
+ if (positions != NULL) positions[(j_voidint)(size_t)t] = 0;
  heap[1] = heap[numels--];
  if (numels)
  {
-  if (positions != NULL) positions[(j_voidint)heap[1]] = 1;
+  if (positions != NULL) positions[(j_voidint)(size_t)heap[1]] = 1;
   downheap(1);
  }
 


### PR DESCRIPTION
Fix the following compilation error on arm64

```
/Users/edelaire1/Documents/software/iso2mesh/tools/meshfix/contrib/JMeshLib/include/clusterGraph.h:57:50: error: cast from pointer to smaller type 'j_voidint' (aka 'int') loses information
 clusterEdge *getFirst() {return (numels)?(edges[(j_voidint)getHead()]):(NULL);} 

```

Solution recomended here: https://stackoverflow.com/questions/22419063/error-cast-from-pointer-to-smaller-type-int-loses-information-in-eaglview-mm/22474752#22474752